### PR TITLE
Added Documentation to Kart Launch Files

### DIFF
--- a/src/kart_2dnav/launch/kart/hector_navigation.launch
+++ b/src/kart_2dnav/launch/kart/hector_navigation.launch
@@ -2,63 +2,93 @@
 
 <launch>
   <!-- TF SETUP -->
-  <!-- Transform from velodyne sensor to kart base -->
-  <node pkg="tf" type="static_transform_publisher" name="base_link_to_velodyne" args="0.40640 0.3683 0 0 0 0 /base_link /velodyne 100">
-  </node>
-  <!-- We may want to put the transform into our own tf_broadcaster like *below* but not now -->
-  <!-- <node pkg="kart_setup_lidar_tf" type="tf_broadcaster" name="robot_tf" output="screen" /> -->
-
   <!-- Set params related to the tf frames used in packages below -->
   <param name="pub_map_odom_transform" value="true"/> 
   <param name="map_frame" value="map"/>
   <param name="base_frame" value="base_link"/>
   <param name="odom_frame" value="base_link"/>
 
+  <!-- Set the static transform from velodyne sensor to kart base -->
+  <node pkg="tf" type="static_transform_publisher" name="base_link_to_velodyne" 
+				args="0.40640 0.3683 0 0 0 0 /base_link /velodyne 100" />
 
   <!-- DRIVER INITIALIZATION (VELODYNE) -->
-  <!-- In this section the Velodyne Sensor will be initialized. Launch 
-       files will be used in order to start outputting
-       the data on the associated topics -->
+  <!-- In this section the Velodyne Sensor will be initialized. Call the launch 
+       file for our LiDAR (VLP-16) to start outputting the LiDAR 3D pointcloud
+       the data on the associated topics (we care about /velodyne_points) -->
   <include file="$(find velodyne_pointcloud)/launch/VLP16_points.launch" />
 
   
   <!-- LASERSCAN SLICING -->
-  <!-- In this next section we will slice up the velodyne pointcloud into a laser scan topic -->
-  <!-- slice up the 3d point cloud into laserscan messages -->
-  <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="pointcloud_to_laserscan">
-      <!-- Uncomment when we want to add custom paramters -->
-      <rosparam file="$(find kart_2dnav)/params/pointcloud_to_laserscan_params.yaml" command="load" />
+  <!-- This node is responsible for taking the 3D point cloud published by 
+	     Velodyne (/velodyne_points)  and publishing messages to a new topic 
+			 (/top/scan) that contain one 2D slice of the 3D pointcloud. --> 
+  <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" 
+				name="pointcloud_to_laserscan">
+      <!-- TODO(zghera): Edit this param file so that we use the 2D scan at a
+			                   pitch of 0 degrees. -->
+      <rosparam file="$(find kart_2dnav)/params/pointcloud_to_laserscan_params.yaml" 
+								command="load" />
+			<!-- Subscribe to topic /velodyne_points for pointcloud input. -->
       <remap from="cloud_in" to="/velodyne_points" />
+			<!-- Publish to topic top/scan rather than default /scan so that we can 
+					 distinguish from the 2D laserscan published by this node vs the default 
+					 scan topic published by the velodyne topics. Always use top/scan because
+					 we can modify the parameters to create the 2D scan where the Velodyne 
+					 default /scan is fixed. -->
       <remap from="scan" to="top/scan" />
   </node>
 
 
   <!-- LASER ODOMETRY -->
-  <!-- Run the laser_scan_matcher to get odom info from the LiDAR -->
-  <node pkg="laser_scan_matcher" type="laser_scan_matcher_node" name="laser_scan_matcher_node" output="screen">
+  <!-- This node is responsible for taking incremental 2D laserscans (/top/scan)
+	     and outputting estimated odometry information as a tf (odom->base_link) 
+			 and by publishing messages to the est_odom_out_pose topic. -->
+  <node pkg="laser_scan_matcher" type="laser_scan_matcher_node" 
+	      name="laser_scan_matcher_node" output="screen">
       <remap from="scan" to="top/scan" />
-      <rosparam file="$(find kart_2dnav)/params/laser_scan_matcher_params.yaml" command="load" />
+      <rosparam file="$(find kart_2dnav)/params/laser_scan_matcher_params.yaml" 
+			          command="load" />
   </node>
 
 
-  <!-- SLAM: LOCALIZATION ("odom") & MAPPING -->
-  <!-- Run the SLAM package in order to localize kart and build map off of laser scans --> 
+  <!-- SLAM: LOCALIZATION & MAPPING -->
+  <!-- Run the SLAM package, HectorMapping, that takes in 2D laser scans 
+	     (/top/scan) and publishes topics for the created map (/map) and 
+			 estimated pose (/slam_out_pose) of the kart relative to the map. 
+			 This node is also responsible for publishing the tf map->odom. --> 
   <node pkg="hector_mapping" type="hector_mapping" name="hector_mapping" output="screen">
-      <rosparam file="$(find kart_2dnav)/params/hector_mapping_params.yaml" command="load" /> 
+      <rosparam file="$(find kart_2dnav)/params/hector_mapping_params.yaml" command="load" /> :q
   </node>
 
   <!-- ROS NAVIGATION STACK -->
-  <!-- Run the move_base to execute the navigation stack -->
+  <!-- Configure and run move_base to set up the ROS Navigation Stack. -->
+  <!-- More details on inputs/outputs can be found in move_base.launch -->
   <include file="$(find kart_2dnav)/launch/kart/move_base.launch" />
 
   <!-- GOAL SETTING -->
-  <!-- Run the goal setting algorithm to navigate without a preliminary map (lap 1) -->
+  <!-- Run the goal setting algorithm to navigate without a preliminary map (lap 1).
+	     This node takes 2D laser scans (/top/scan) then constructs a goal message and 
+			 creates an ActionClient to sends the goal as ROS actions to SimpleActionServer 
+			 on move_base.
+			 Note: /move_base_simple/goal is a non-action topic that move_base subsribes 
+			 to in case users don't want to use the ActionServer but all of our goals 
+			 go through the action server. When looking at an rqt_graph or visualizing 
+			 the connections of nodes, you can think of slam_mode_goal publishing to 
+			 /move_base_simple/goal which move_base subscribes to. But know that in 
+			 actuality, slam_mode_goal node is sending ROS Actions to the move_base 
+			 ActionAPI to send move_base new goals to pursue (move_base will get these 
+			 from move_base/goal Action Topic). 
+			 For more info see http://wiki.ros.org/move_base#Action_API. -->
   <!-- TODO(?): figure out how to incorporate ROS params with goal setting script -->
   <node pkg="slam_mode_goal" type="slam_mode_goal" name="slam_mode_goal" output="screen">
   </node>
 
   <!-- MICROCONTROLLER COMM -->
-  <!-- Run the communication script to enable and start communicating with microcontroller -->
+  <!-- Run the communication script to enable and start communicating with the 
+	     microcontroller. This node subscribed to the /cmd_vel topic published by 
+			 move_base and then then sends packets containing the velocity and steering 
+			 angle to the MCU over a serial connection. -->
   <node pkg="ti_comm" type="ti_comm_node" name="ti_comm_node" output="screen" />
 
   <!-- Launch rviz with the configuration file in order to visualize incoming data -->

--- a/src/kart_2dnav/launch/kart/move_base.launch
+++ b/src/kart_2dnav/launch/kart/move_base.launch
@@ -2,6 +2,8 @@
 
 <!-- Run move_base node (with TebLocalPlannerROS as the local planner) to execute the navigation stack -->
 
+<!-- TODO(zghera): Add some more notes about how move_base interacts with tf and how tf somehow transfers the pose estimates from laserscan_matcher_node (odometry) and hector_mapping (localization via slam_out_pose or poseupdate topicsi or maybe even through tf map->odom) to the tf topic before feeding into move_base. Whenshould topics be published vs asking node to create transforms vs both? Should also look if we should be publishing anything to the odom frame for move_base to use. -->
+
 <launch>
     <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
         <rosparam file="$(find kart_2dnav)/params/costmap_common_params.yaml" command="load" ns="global_costmap" /> 

--- a/src/kart_2dnav/launch/sim/sim_autocross_track.launch
+++ b/src/kart_2dnav/launch/sim/sim_autocross_track.launch
@@ -20,7 +20,7 @@
 		<remap from="base_scan" to="top/scan"/>
   </node>
 
-  <!--  ************** Navigation ***************  -->
+  <!--  ************** ROS Navigation Stack (move_base) ***************  -->
 	<node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
       <rosparam file="$(find teb_local_planner_tutorials)/cfg/carlike/costmap_common_params.yaml" command="load" ns="global_costmap" />
 			<!-- Modified teb_local_planner_tutorials version to set laserscan input to move_base come from top/scan -->
@@ -37,7 +37,8 @@
 		<param name="controller_frequency" value="5.0" />
 		<param name="controller_patience" value="15.0" />
 
-    <param name="clearing_rotation_allowed" value="false" />  <!-- Our carlike robot is not able to rotate in place -->
+		<!-- Our carlike robot is not able to rotate in place -->
+    <param name="clearing_rotation_allowed" value="false" />  
 	</node>
 
   <!-- Run the goal setting script to navigate in SLAM mode -->

--- a/src/kart_2dnav/params/laser_scan_matcher_params.yaml
+++ b/src/kart_2dnav/params/laser_scan_matcher_params.yaml
@@ -2,15 +2,18 @@
 
 # frame coordination
 base_frame: "base_link"
+
+# This is the fixed world frame which is the parent frame of map. Check out this here:www.ros.org/reps/rep-0105.html. Need to do some more research on how to related odom (world) and map though.
 fixed_frame: "odom"      # Where else do we use this? 
                          # And how is this different from "global_frame: map" in global_costmap_params?
 
 # scan matcher parameters
-use_imu: "false"
-use_odom: "false"
-use_vel: "false"
+use_imu: false
+use_odom: false
+use_vel: false
 max_iterations: 10
 
 # output topics
-publish_tf: False
-publish_pose: True
+publish_tf: true
+publish_pose: false
+publish_pose_stamped: true


### PR DESCRIPTION
## What is a quick description of the change?
Added a lot more documentation to each of the sections in the kart launch file, `hector_navigation.launch`, based on the current understanding of the system. 

## Is this fixing an issue?
No

## Are there more details that are relevant?
This added documentation is likely temporary and will be moved over to external documentation like the AMP v1 design doc. But for now, keeping it here makes sense as it will likely be updating alongside the proceeding launch file PRs with newly uncovered knowledge and changes to the system.

In addition to the main changes in hector_navigation.launch, there were a few changes in other files:
- `move_base.launch`: A TODO on what needs to be added in terms of documentation in this file moving forward (mirroring the type of documentation in `hector_navigation.launch`).
- `sim_autocross_track.launch`: Small comment changes.
- `laser_scan_matcher_params.yaml `: Added a note on findings from discovering [REP 105](https://www.ros.org/reps/rep-0105.html) from [this ROS post](https://github.com/cartographer-project/cartographer_ros/issues/300). Also corrected datatypes of some parameters to start playing around with this param file to see its effects on the rqt_graph for `hector_navigation.launch`.

## Check lists (check x in [ ] of list items)
- [ ] Test written/updating
- [ ] Tests passing
- [x] Coding style (indentation, etc)

No testing needed for launch file development.

## Any additional comments?
As compared to PR #1 this is a much better example of a good PR as it is:
- Small (number of lines changes). Try to keep most PRs under ~200 lines of changes if possible, but the smaller the better.
- Only makes one change (for the most part)
- Has a good full PR description