### PR TITLE
Added troubleshooting section in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,10 @@ roslaunch kart_2dnav sim_autocross_track.launch
 ```
 
 See the individual launch files in  `src/kart_2dnav/launch/` for more info on the purpose/configuration of that launch file.
+
+## Troubleshooting
+A secion outlining common issues and their fixes.
+* If an error is encountered claiming that a number of packages were not found, or that modules are not present. Try updating all dependencies in the Kinetic ROS installation with:
+```
+rosdep update --include-eol-distros
+```


### PR DESCRIPTION
## What is a quick description of the change?
Added troubleshooting section in readme.md. When updating ros dependencies, a flag will be needed to make sure Kinetic dependencies are updated.

## Is this fixing an issue?
No

## Were any issues created as a result of this change?
No

## Are there more details that are relevant?
The section can be used to further add helpful comments. In future, might be worthwhile to create a separate markdown document listing these comments.

## Check lists (check x in [ ] of list items)
- [x] Test written/updating
- [x] Tests passing
- [x] Coding style (indentation, etc)

## Any additional comments?
