### PR TITLE
Gitignore MacOS trash and debug files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,7 @@
 /src/kart_setup_odom_tf/.idea/**
 
 # Debug files
-/src/ti_comm/src/test/debug.txt
-/src/ti_comm/src/test/debug_tx.txt
-/src/ti_comm/src/test/debug_rx.txt
+/src/ti_comm/src/test/*.txt
 
 # MacOS
 .DS_STORE

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,17 @@
 /src/sbg_to_imu/.idea/**
 /src/kart_setup_odom_tf/.idea/**
 
+# Debug files
+/src/ti_comm/src/test/debug.txt
+/src/ti_comm/src/test/debug_tx.txt
+/src/ti_comm/src/test/debug_rx.txt
+
+# MacOS
+.DS_STORE
+.DS_STORE?
+.Spotlight-V100
+.Trashes
+*.dSYM
+*.xml
+*.iml
+


### PR DESCRIPTION
Adds to gitignore:
- MacOS trash and log files
- xml files
- serial testing: debug.txt 
- serial testing: debug_rx.txt
- serial testing: debug_tx.txt